### PR TITLE
API: Generalize API for Oni2

### DIFF
--- a/src/Notification.re
+++ b/src/Notification.re
@@ -1,20 +1,20 @@
-  type t = {
-    method: string,
-    params: Yojson.Safe.json,
-  };
+type t = {
+  method: string,
+  params: Yojson.Safe.json,
+};
 
-  let is = (msg: Yojson.Safe.json) =>
-    Utility.hasMethod(msg) && !Utility.hasId(msg);
+let is = (msg: Yojson.Safe.json) =>
+  Utility.hasMethod(msg) && !Utility.hasId(msg);
 
-  let parse = (msg: Yojson.Safe.json) => {
-    let method =
-      msg |> Yojson.Safe.Util.member("method") |> Yojson.Safe.Util.to_string;
+let parse = (msg: Yojson.Safe.json) => {
+  let method =
+    msg |> Yojson.Safe.Util.member("method") |> Yojson.Safe.Util.to_string;
 
-    let params = msg |> Yojson.Safe.Util.member("params");
+  let params = msg |> Yojson.Safe.Util.member("params");
 
-    {method, params};
-  };
+  {method, params};
+};
 
-  let show = (v: t) => {
-    "[Notification - " ++ v.method ++ "]: " ++ Yojson.Safe.to_string(v.params);
-  };
+let show = (v: t) => {
+  "[Notification - " ++ v.method ++ "]: " ++ Yojson.Safe.to_string(v.params);
+};

--- a/src/Notification.re
+++ b/src/Notification.re
@@ -1,20 +1,3 @@
-module Request = {
-  type t = (string, Yojson.Safe.json);
-
-  let is = (msg: Yojson.Safe.json) =>
-    Utility.hasMethod(msg) && Utility.hasId(msg);
-
-  let parse = (msg: Yojson.Safe.json) => {
-    let method =
-      msg |> Yojson.Safe.Util.member("method") |> Yojson.Safe.Util.to_string;
-
-    let params = msg |> Yojson.Safe.Util.member("params");
-
-    (method, params);
-  };
-};
-
-module Notification = {
   type t = {
     method: string,
     params: Yojson.Safe.json,
@@ -35,4 +18,3 @@ module Notification = {
   let show = (v: t) => {
     "[Notification - " ++ v.method ++ "]: " ++ Yojson.Safe.to_string(v.params);
   };
-};

--- a/src/Request.re
+++ b/src/Request.re
@@ -1,0 +1,13 @@
+type t = (string, Yojson.Safe.json);
+
+let is = (msg: Yojson.Safe.json) =>
+Utility.hasMethod(msg) && Utility.hasId(msg);
+
+let parse = (msg: Yojson.Safe.json) => {
+let method =
+  msg |> Yojson.Safe.Util.member("method") |> Yojson.Safe.Util.to_string;
+
+let params = msg |> Yojson.Safe.Util.member("params");
+
+(method, params);
+};

--- a/src/Request.re
+++ b/src/Request.re
@@ -1,13 +1,13 @@
 type t = (string, Yojson.Safe.json);
 
 let is = (msg: Yojson.Safe.json) =>
-Utility.hasMethod(msg) && Utility.hasId(msg);
+  Utility.hasMethod(msg) && Utility.hasId(msg);
 
 let parse = (msg: Yojson.Safe.json) => {
-let method =
-  msg |> Yojson.Safe.Util.member("method") |> Yojson.Safe.Util.to_string;
+  let method =
+    msg |> Yojson.Safe.Util.member("method") |> Yojson.Safe.Util.to_string;
 
-let params = msg |> Yojson.Safe.Util.member("params");
+  let params = msg |> Yojson.Safe.Util.member("params");
 
-(method, params);
+  (method, params);
 };

--- a/src/Rpc.re
+++ b/src/Rpc.re
@@ -1,5 +1,3 @@
-open Types;
-
 type t = {
   input: in_channel,
   output: out_channel,

--- a/src/Rpc.re
+++ b/src/Rpc.re
@@ -39,9 +39,11 @@ let parse: string => message =
 
     switch (Notification.is(p), Request.is(p)) {
     | (true, _) => 
+        Log.debug("--parsing notification");
         let result = Notification.parse(p);
         Notification(result);
     | (_, true) =>
+      Log.debug("--parsing request");
       let id = p |> Yojson.Safe.Util.member("id") |> Yojson.Safe.Util.to_int;
       Request(id, Request.parse(p));
     | _ => Response
@@ -74,6 +76,7 @@ let start =
     Log.debug("Received msg: " ++ str);
 
     let result = parse(str);
+    Log.debug("Parsed message.");
 
     switch (result) {
     | Notification(v) => onNotification(v, rpc)

--- a/src/Rpc.rei
+++ b/src/Rpc.rei
@@ -4,7 +4,15 @@ type notificationHandler = (Notification.t, t) => unit;
 type requestHandler = (Request.t, t) => result(Yojson.Safe.json, string);
 type closeHandler = unit => unit;
 
-let start: (~onNotification:notificationHandler, ~onRequest:requestHandler, ~onClose:closeHandler, in_channel, out_channel) => t;
+let start:
+  (
+    ~onNotification: notificationHandler,
+    ~onRequest: requestHandler,
+    ~onClose: closeHandler,
+    in_channel,
+    out_channel
+  ) =>
+  t;
 
 let sendNotification: (t, string, Yojson.Safe.json) => unit;
 
@@ -13,4 +21,4 @@ let sendNotification: (t, string, Yojson.Safe.json) => unit;
  */
 let pump: t => unit;
 
-let stop: (t) => unit;
+let stop: t => unit;

--- a/src/Rpc.rei
+++ b/src/Rpc.rei
@@ -1,0 +1,10 @@
+type t;
+
+type notificationHandler = (Notification.t, t) => unit;
+type requestHandler = (Request.t, t) => result(Yojson.Safe.json, string);
+
+let start: (~onNotification:notificationHandler, ~onRequest:requestHandler, in_channel, out_channel) => t;
+
+let sendNotification = (t, string, Yojson.Safe.json) => unit;
+
+let stop: (t) => unit;

--- a/src/Rpc.rei
+++ b/src/Rpc.rei
@@ -2,9 +2,15 @@ type t;
 
 type notificationHandler = (Notification.t, t) => unit;
 type requestHandler = (Request.t, t) => result(Yojson.Safe.json, string);
+type closeHandler = unit => unit;
 
-let start: (~onNotification:notificationHandler, ~onRequest:requestHandler, in_channel, out_channel) => t;
+let start: (~onNotification:notificationHandler, ~onRequest:requestHandler, ~onClose:closeHandler, in_channel, out_channel) => t;
 
-let sendNotification = (t, string, Yojson.Safe.json) => unit;
+let sendNotification: (t, string, Yojson.Safe.json) => unit;
+
+/*
+ * Calling 'pump' is required to handle pending notifications and requests
+ */
+let pump: t => unit;
 
 let stop: (t) => unit;

--- a/src/Types.re
+++ b/src/Types.re
@@ -1,40 +1,38 @@
-module Request {
+module Request = {
+  type t = (string, Yojson.Safe.json);
 
-    type t = (string, Yojson.Safe.json);
+  let is = (msg: Yojson.Safe.json) =>
+    Utility.hasMethod(msg) && Utility.hasId(msg);
 
-    let is = (msg: Yojson.Safe.json) =>
-        Utility.hasMethod(msg) && Utility.hasId(msg);
+  let parse = (msg: Yojson.Safe.json) => {
+    let method =
+      msg |> Yojson.Safe.Util.member("method") |> Yojson.Safe.Util.to_string;
 
-    let parse = (msg: Yojson.Safe.json) => {
-        let method = msg
-            |> Yojson.Safe.Util.member("method") |> Yojson.Safe.Util.to_string;
+    let params = msg |> Yojson.Safe.Util.member("params");
 
-        let params = msg |> Yojson.Safe.Util.member("params");
+    (method, params);
+  };
+};
 
-        (method, params);
-    };
-}
+module Notification = {
+  type t = {
+    method: string,
+    params: Yojson.Safe.json,
+  };
 
-module Notification {
-    type t = {
-        method: string,
-        params: Yojson.Safe.json,
-    };
+  let is = (msg: Yojson.Safe.json) =>
+    Utility.hasMethod(msg) && !Utility.hasId(msg);
 
-    let is = (msg: Yojson.Safe.json) => 
-        Utility.hasMethod(msg) && !Utility.hasId(msg);
+  let parse = (msg: Yojson.Safe.json) => {
+    let method =
+      msg |> Yojson.Safe.Util.member("method") |> Yojson.Safe.Util.to_string;
 
-    let parse = (msg: Yojson.Safe.json) => {
-        let method = msg
-            |> Yojson.Safe.Util.member("method") |> Yojson.Safe.Util.to_string;
+    let params = msg |> Yojson.Safe.Util.member("params");
 
-        let params = msg |> Yojson.Safe.Util.member("params");
+    {method, params};
+  };
 
-        {method, params};
-    };
-
-    let show = (v: t) => {
-        "[Notification - " ++ v.method ++ "]: " ++ Yojson.Safe.to_string(v.params);
-    }
-
-}
+  let show = (v: t) => {
+    "[Notification - " ++ v.method ++ "]: " ++ Yojson.Safe.to_string(v.params);
+  };
+};

--- a/src/Types.re
+++ b/src/Types.re
@@ -3,7 +3,7 @@ module Request {
     type t = (string, Yojson.Safe.json);
 
     let is = (msg: Yojson.Safe.json) =>
-        Utility.hasMethod(msg) && !Utility.hasId(msg);
+        Utility.hasMethod(msg) && Utility.hasId(msg);
 
     let parse = (msg: Yojson.Safe.json) => {
         let method = msg
@@ -16,10 +16,13 @@ module Request {
 }
 
 module Notification {
-    type t = (string, Yojson.Safe.json);
+    type t = {
+        method: string,
+        params: Yojson.Safe.json,
+    };
 
     let is = (msg: Yojson.Safe.json) => 
-        Utility.hasMethod(msg) && Utility.hasId(msg);
+        Utility.hasMethod(msg) && !Utility.hasId(msg);
 
     let parse = (msg: Yojson.Safe.json) => {
         let method = msg
@@ -27,7 +30,11 @@ module Notification {
 
         let params = msg |> Yojson.Safe.Util.member("params");
 
-        (method, params);
+        {method, params};
     };
+
+    let show = (v: t) => {
+        "[Notification - " ++ v.method ++ "]: " ++ Yojson.Safe.to_string(v.params);
+    }
 
 }


### PR DESCRIPTION
- Make `Rpc.start` non-blocking
- Move message processing to thread, but allow 'main' thread to determine when to handle (`Rpc.pump`) - to fit into Oni/Revery's processing model.