### PR TITLE
Bugfix: Long messages can break RPC

### DIFF
--- a/src/Rpc.re
+++ b/src/Rpc.re
@@ -161,12 +161,11 @@ let start =
             let buffer = Bytes.create(len);
             let read = ref(0);
             while (read^ < len) {
-              let n = Pervasives.input(input, buffer, 0, len);
+              let n = Pervasives.input(input, buffer, read^, len - read^);
               read := read^ + n;
             };
 
             let str = Bytes.to_string(buffer);
-
             let result = _parse(str);
 
             queueMessage(result);


### PR DESCRIPTION
__Issue:__ Onivim 2 would crash intermittently with long messages via json-rpc, during JSON parsing (due to invalid JSON)

__Defect:__ When data from `input` can be read in a single go, all is well. But if it's broken up - we'll get a crash. There was a bug with the way we were calling `Pervasives.input` that caused it to always write at 0.

__Fix:__ Correct the `pos`, `len` parameters of `Pervasives.input` to correctly handle cases where the input gets chunked.