### PR TITLE
fix(pencil): remove debug logging

### DIFF
--- a/src/Rpc.re
+++ b/src/Rpc.re
@@ -155,7 +155,6 @@ let start =
           | exception End_of_file => rpc.shouldClose = true
           | preamble =>
             let len = preamble.contentLength;
-            Log.debug("Message length: " ++ string_of_int(len));
 
             /* Read message */
             let buffer = Bytes.create(len);


### PR DESCRIPTION
In Onivim 2, we'd get a bunch of superfluous logging like:
```
[DEBUG] Message length: 52
[DEBUG] Message length: 165
[DEBUG] Message length: 83
[DEBUG] Message length: 83
[DEBUG] Message length: 196
[DEBUG] Message length: 154
[DEBUG] Message length: 236
```

This came from `reason-jsonrpc`. Will disable this logging for now - we can always add it back, tucked behind a setting, if it is useful for a consumer.