### PR TITLE
Support OCaml 4.08

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "a4967efe8031b88bcc43b05f6cc20195",
+  "checksum": "b70bee7a4a2104d4415edfcef14f7e2e",
   "root": "reason-jsonrpc@link-dev:./package.json",
   "node": {
     "refmterr@3.2.2@d41d8cd9": {
@@ -14,11 +14,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@reason-native/pastel@0.2.1@d41d8cd9",
+        "ocaml@4.8.1000@d41d8cd9", "@reason-native/pastel@0.2.1@d41d8cd9",
         "@reason-native/console@0.1.0@d41d8cd9",
-        "@opam/re@opam:1.9.0@fc2ceb05", "@opam/dune@opam:1.11.3@9894df55",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:1.11.3@9894df55",
         "@opam/atdgen@opam:2.0.0@5d912e07",
-        "@esy-ocaml/reason@3.5.0@d41d8cd9"
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -33,24 +33,24 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "@reason-native/rely@3.1.0@d41d8cd9",
         "@opam/yojson@opam:1.7.0@7056d985",
-        "@opam/merlin@opam:3.3.2@7a364181", "@opam/lwt@opam:4.3.0@3f2cb6e0",
-        "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/reason@3.5.0@d41d8cd9"
+        "@opam/merlin@opam:3.3.2@7a364181", "@opam/lwt@opam:4.3.1@14b6a62e",
+        "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/merlin@opam:3.3.2@7a364181"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/merlin@opam:3.3.2@7a364181"
       ]
     },
-    "ocaml@4.7.1004@d41d8cd9": {
-      "id": "ocaml@4.7.1004@d41d8cd9",
+    "ocaml@4.8.1000@d41d8cd9": {
+      "id": "ocaml@4.8.1000@d41d8cd9",
       "name": "ocaml",
-      "version": "4.7.1004",
+      "version": "4.8.1000",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/ocaml/-/ocaml-4.7.1004.tgz#sha1:731ca0ddb4d845d2ed2da8af50f70c5ba9092114"
+          "archive:https://registry.npmjs.org/ocaml/-/ocaml-4.8.1000.tgz#sha1:abc435b5d4ddea2acba8b2df7efb81e2d1690db1"
         ]
       },
       "overrides": [],
@@ -69,11 +69,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "refmterr@3.2.2@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
+        "refmterr@3.2.2@d41d8cd9", "ocaml@4.8.1000@d41d8cd9",
         "@reason-native/pastel@0.2.1@d41d8cd9",
         "@reason-native/file-context-printer@0.0.3@d41d8cd9",
-        "@opam/re@opam:1.9.0@fc2ceb05", "@opam/junit@opam:2.0.1@8972ddca",
-        "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/reason@3.5.0@d41d8cd9"
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/junit@opam:2.0.1@1b4d302c",
+        "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -89,8 +89,8 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
-        "@esy-ocaml/reason@3.5.0@d41d8cd9"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -106,9 +106,9 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@reason-native/pastel@0.2.1@d41d8cd9",
-        "@opam/re@opam:1.9.0@fc2ceb05", "@opam/dune@opam:1.11.3@9894df55",
-        "@esy-ocaml/reason@3.5.0@d41d8cd9"
+        "ocaml@4.8.1000@d41d8cd9", "@reason-native/pastel@0.2.1@d41d8cd9",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:1.11.3@9894df55",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -124,8 +124,8 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
-        "@esy-ocaml/reason@3.5.0@d41d8cd9"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -147,13 +147,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@opam/dune@opam:1.11.3@9894df55", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/biniou@opam:1.2.1@d7570399",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@opam/dune@opam:1.11.3@9894df55", "@opam/biniou@opam:1.2.1@d7570399"
       ]
     },
@@ -175,14 +175,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea",
         "@opam/topkg@opam:1.0.1@a42c631e",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/uchar@opam:0.0.2@c8218eea"
       ]
     },
     "@opam/uchar@opam:0.0.2@c8218eea": {
@@ -203,13 +203,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/tyxml@opam:4.3.0@9dca4c30": {
-      "id": "@opam/tyxml@opam:4.3.0@9dca4c30",
+    "@opam/tyxml@opam:4.3.0@c1da25f1": {
+      "id": "@opam/tyxml@opam:4.3.0@c1da25f1",
       "name": "@opam/tyxml",
       "version": "opam:4.3.0",
       "source": {
@@ -226,13 +226,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
-        "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.9.0@fc2ceb05",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.9.0@d4d5e13d",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
-        "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.9.0@fc2ceb05",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/uutf@opam:1.0.2@4440868f",
+        "@opam/seq@opam:base@d8d7de1d", "@opam/re@opam:1.9.0@d4d5e13d",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
@@ -254,12 +254,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@427a2331"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlbuild@opam:0.14.0@6ac75d03"
       ]
     },
     "@opam/seq@opam:base@d8d7de1d": {
@@ -277,12 +277,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "ocaml@4.8.1000@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/result@opam:1.4@6fb665c3": {
-      "id": "@opam/result@opam:1.4@6fb665c3",
+    "@opam/result@opam:1.4@dc720aef": {
+      "id": "@opam/result@opam:1.4@dc720aef",
       "name": "@opam/result",
       "version": "opam:1.4",
       "source": {
@@ -299,15 +299,15 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/re@opam:1.9.0@fc2ceb05": {
-      "id": "@opam/re@opam:1.9.0@fc2ceb05",
+    "@opam/re@opam:1.9.0@d4d5e13d": {
+      "id": "@opam/re@opam:1.9.0@d4d5e13d",
       "name": "@opam/re",
       "version": "opam:1.9.0",
       "source": {
@@ -324,11 +324,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
@@ -350,18 +350,18 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
-        "@opam/result@opam:1.4@6fb665c3",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/result@opam:1.4@dc720aef",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@6fb665c3"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef"
       ]
     },
-    "@opam/ppx_derivers@opam:1.2.1@aee9c3db": {
-      "id": "@opam/ppx_derivers@opam:1.2.1@aee9c3db",
+    "@opam/ppx_derivers@opam:1.2.1@ecf0aa45": {
+      "id": "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
       "name": "@opam/ppx_derivers",
       "version": "opam:1.2.1",
       "source": {
@@ -378,11 +378,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/ocplib-endian@opam:1.0@aa720242": {
@@ -408,14 +408,14 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-bytes@opam:base@19d0c2ff",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-bytes@opam:base@19d0c2ff"
       ]
@@ -444,13 +444,13 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/conf-m4@opam:1@da6f4f44",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/conf-m4@opam:1@3b2b148a",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/ocamlbuild@opam:0.14.0@427a2331": {
-      "id": "@opam/ocamlbuild@opam:0.14.0@427a2331",
+    "@opam/ocamlbuild@opam:0.14.0@6ac75d03": {
+      "id": "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
       "name": "@opam/ocamlbuild",
       "version": "opam:0.14.0",
       "source": {
@@ -472,12 +472,12 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "ocaml@4.8.1000@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334": {
-      "id": "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+    "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d": {
+      "id": "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
       "name": "@opam/ocaml-migrate-parsetree",
       "version": "opam:1.4.0",
       "source": {
@@ -494,18 +494,18 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ppx_derivers@opam:1.2.1@aee9c3db",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
+        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
-        "@opam/ppx_derivers@opam:1.2.1@aee9c3db",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
+        "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/mmap@opam:1.1.0@7bef1e51": {
-      "id": "@opam/mmap@opam:1.1.0@7bef1e51",
+    "@opam/mmap@opam:1.1.0@b85334ff": {
+      "id": "@opam/mmap@opam:1.1.0@b85334ff",
       "name": "@opam/mmap",
       "version": "opam:1.1.0",
       "source": {
@@ -522,11 +522,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/merlin-extend@opam:0.5@a5dd7d4b": {
@@ -547,11 +547,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@opam/cppo@opam:1.6.6@f4f83858", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/merlin@opam:3.3.2@7a364181": {
@@ -572,76 +572,79 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/menhir@opam:20190626@bbeb8953": {
-      "id": "@opam/menhir@opam:20190626@bbeb8953",
+    "@opam/menhir@opam:20190924@004407ff": {
+      "id": "@opam/menhir@opam:20190924@004407ff",
       "name": "@opam/menhir",
-      "version": "opam:20190626",
+      "version": "opam:20190924",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/78/783961f8d124449a1a335cc8e50f013f#md5:783961f8d124449a1a335cc8e50f013f",
-          "archive:https://gitlab.inria.fr/fpottier/menhir/repository/20190626/archive.tar.gz#md5:783961f8d124449a1a335cc8e50f013f"
+          "archive:https://opam.ocaml.org/cache/md5/67/677f1997fb73177d5a00fa1b8d61c3ef#md5:677f1997fb73177d5a00fa1b8d61c3ef",
+          "archive:https://gitlab.inria.fr/fpottier/menhir/repository/20190924/archive.tar.gz#md5:677f1997fb73177d5a00fa1b8d61c3ef"
         ],
         "opam": {
           "name": "menhir",
-          "version": "20190626",
-          "path": "esy.lock/opam/menhir.20190626"
+          "version": "20190924",
+          "path": "esy.lock/opam/menhir.20190924"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocamlbuild@opam:0.14.0@427a2331",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
-      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+      "devDependencies": [ "ocaml@4.8.1000@d41d8cd9" ]
     },
-    "@opam/lwt@opam:4.3.0@3f2cb6e0": {
-      "id": "@opam/lwt@opam:4.3.0@3f2cb6e0",
+    "@opam/lwt@opam:4.3.1@14b6a62e": {
+      "id": "@opam/lwt@opam:4.3.1@14b6a62e",
       "name": "@opam/lwt",
-      "version": "opam:4.3.0",
+      "version": "opam:4.3.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/1a/1a72b5ae4245707c12656632a25fc18c#md5:1a72b5ae4245707c12656632a25fc18c",
-          "archive:https://github.com/ocsigen/lwt/archive/4.3.0.tar.gz#md5:1a72b5ae4245707c12656632a25fc18c"
+          "archive:https://opam.ocaml.org/cache/md5/92/926936860087c5819d6ca04241bc894a#md5:926936860087c5819d6ca04241bc894a",
+          "archive:https://github.com/ocsigen/lwt/archive/4.3.1.tar.gz#md5:926936860087c5819d6ca04241bc894a"
         ],
         "opam": {
           "name": "lwt",
-          "version": "4.3.0",
-          "path": "esy.lock/opam/lwt.4.3.0"
+          "version": "4.3.1",
+          "path": "esy.lock/opam/lwt.4.3.1"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/result@opam:1.4@6fb665c3",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
+        "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@7bef1e51", "@opam/dune@opam:1.11.3@9894df55",
-        "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.3@9894df55", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base-threads@opam:base@36803084",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/result@opam:1.4@6fb665c3",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
+        "@opam/result@opam:1.4@dc720aef",
         "@opam/ocplib-endian@opam:1.0@aa720242",
-        "@opam/mmap@opam:1.1.0@7bef1e51", "@opam/dune@opam:1.11.3@9894df55"
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
-    "@opam/junit@opam:2.0.1@8972ddca": {
-      "id": "@opam/junit@opam:2.0.1@8972ddca",
+    "@opam/junit@opam:2.0.1@1b4d302c": {
+      "id": "@opam/junit@opam:2.0.1@1b4d302c",
       "name": "@opam/junit",
       "version": "opam:2.0.1",
       "source": {
@@ -658,11 +661,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/tyxml@opam:4.3.0@9dca4c30", "@opam/ptime@opam:0.8.5@0051d642",
+        "@opam/tyxml@opam:4.3.0@c1da25f1", "@opam/ptime@opam:0.8.5@0051d642",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/tyxml@opam:4.3.0@9dca4c30", "@opam/ptime@opam:0.8.5@0051d642",
+        "@opam/tyxml@opam:4.3.0@c1da25f1", "@opam/ptime@opam:0.8.5@0051d642",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
@@ -681,11 +684,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {
@@ -706,12 +709,31 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55"
       ]
+    },
+    "@opam/dune-configurator@opam:1.0.0@4873acd8": {
+      "id": "@opam/dune-configurator@opam:1.0.0@4873acd8",
+      "name": "@opam/dune-configurator",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "dune-configurator",
+          "version": "1.0.0",
+          "path": "esy.lock/opam/dune-configurator.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "@opam/dune@opam:1.11.3@9894df55" ]
     },
     "@opam/dune@opam:1.11.3@9894df55": {
       "id": "@opam/dune@opam:1.11.3@9894df55",
@@ -736,12 +758,12 @@
         }
       ],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/base-unix@opam:base@87d0b2eb",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base-threads@opam:base@36803084",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/base-unix@opam:base@87d0b2eb",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/base-unix@opam:base@87d0b2eb",
         "@opam/base-threads@opam:base@36803084"
       ]
     },
@@ -763,17 +785,17 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/dune@opam:1.11.3@9894df55",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
-    "@opam/conf-m4@opam:1@da6f4f44": {
-      "id": "@opam/conf-m4@opam:1@da6f4f44",
+    "@opam/conf-m4@opam:1@3b2b148a": {
+      "id": "@opam/conf-m4@opam:1@3b2b148a",
       "name": "@opam/conf-m4",
       "version": "opam:1",
       "source": {
@@ -807,11 +829,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@opam/dune@opam:1.11.3@9894df55", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@opam/dune@opam:1.11.3@9894df55"
       ]
     },
@@ -864,11 +886,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9"
       ]
     },
     "@opam/atdgen-runtime@opam:2.0.0@8a75c3bb": {
@@ -889,13 +911,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/biniou@opam:1.2.1@d7570399",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/biniou@opam:1.2.1@d7570399"
       ]
     },
@@ -917,14 +939,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/biniou@opam:1.2.1@d7570399",
         "@opam/atdgen-runtime@opam:2.0.0@8a75c3bb",
         "@opam/atd@opam:2.0.0@087614b7", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/yojson@opam:1.7.0@7056d985",
         "@opam/biniou@opam:1.2.1@d7570399",
         "@opam/atdgen-runtime@opam:2.0.0@8a75c3bb",
         "@opam/atd@opam:2.0.0@087614b7"
@@ -948,13 +970,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/menhir@opam:20190626@bbeb8953",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/menhir@opam:20190924@004407ff",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/easy-format@opam:1.3.2@0484b3c4",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4"
+        "ocaml@4.8.1000@d41d8cd9", "@opam/easy-format@opam:1.3.2@0484b3c4"
       ]
     },
     "@esy-ocaml/substs@0.0.1@d41d8cd9": {
@@ -971,23 +993,23 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "@esy-ocaml/reason@3.5.0@d41d8cd9": {
-      "id": "@esy-ocaml/reason@3.5.0@d41d8cd9",
+    "@esy-ocaml/reason@3.5.2@d41d8cd9": {
+      "id": "@esy-ocaml/reason@3.5.2@d41d8cd9",
       "name": "@esy-ocaml/reason",
-      "version": "3.5.0",
+      "version": "3.5.2",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@esy-ocaml/reason/-/reason-3.5.0.tgz#sha1:f276b991ef0dfe4d559b68e554661f8b2bc618bf"
+          "archive:https://registry.npmjs.org/@esy-ocaml/reason/-/reason-3.5.2.tgz#sha1:ac48b63fd66fbbc1d77ab6a2b7e3a1ba21a8f40b"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@6fb665c3",
+        "ocaml@4.8.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@opam/ocaml-migrate-parsetree@opam:1.4.0@7f2e4334",
+        "@opam/ocaml-migrate-parsetree@opam:1.4.0@0c4ec62d",
         "@opam/merlin-extend@opam:0.5@a5dd7d4b",
-        "@opam/menhir@opam:20190626@bbeb8953",
+        "@opam/menhir@opam:20190924@004407ff",
         "@opam/dune@opam:1.11.3@9894df55"
       ],
       "devDependencies": []

--- a/esy.lock/opam/conf-m4.1/opam
+++ b/esy.lock/opam/conf-m4.1/opam
@@ -3,7 +3,7 @@ maintainer: "tim@gfxmonk.net"
 homepage: "http://www.gnu.org/software/m4/m4.html"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "GNU Project"
-license: "GPL-3"
+license: "GPL-3.0-only"
 build: [["sh" "-exc" "echo | m4"]]
 depexts: [
   ["m4"] {os-family = "debian"}

--- a/esy.lock/opam/dune-configurator.1.0.0/opam
+++ b/esy.lock/opam/dune-configurator.1.0.0/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+maintainer: "Jérémie Dimino"
+description: """
+dune.configurator library distributed with Dune 1.x
+"""
+depends: ["dune" {<"2.0.0"}]

--- a/esy.lock/opam/junit.2.0.1/opam
+++ b/esy.lock/opam/junit.2.0.1/opam
@@ -3,7 +3,7 @@ maintainer: "Louis Roché <louis@louisroche.net>"
 authors: "Louis Roché <louis@louisroche.net>"
 homepage: "https://github.com/Khady/ocaml-junit"
 bug-reports: "https://github.com/Khady/ocaml-junit/issues"
-license: "LGPLv3+ with OCaml linking exception"
+license: "LGPL-3.0-or-later with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/Khady/ocaml-junit.git"
 doc: "https://khady.github.io/ocaml-junit/"
 tags: ["junit" "jenkins"]

--- a/esy.lock/opam/lwt.4.3.1/opam
+++ b/esy.lock/opam/lwt.4.3.1/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 
 synopsis: "Promises and event-driven I/O"
 
-version: "4.3.0"
+version: "4.3.1"
 license: "MIT"
 homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt/manual/"
@@ -20,6 +20,7 @@ dev-repo: "git+https://github.com/ocsigen/lwt.git"
 depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.7.0"}
+  "dune-configurator"
   "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
   "ocaml" {>= "4.02.0"}
   "ocplib-endian"
@@ -59,6 +60,6 @@ a single thread by default. This reduces the need for locks or other
 synchronization primitives. Code can be run in parallel on an opt-in basis."
 
 url {
-  src: "https://github.com/ocsigen/lwt/archive/4.3.0.tar.gz"
-  checksum: "md5=1a72b5ae4245707c12656632a25fc18c"
+  src: "https://github.com/ocsigen/lwt/archive/4.3.1.tar.gz"
+  checksum: "md5=926936860087c5819d6ca04241bc894a"
 }

--- a/esy.lock/opam/menhir.20190924/opam
+++ b/esy.lock/opam/menhir.20190924/opam
@@ -21,9 +21,9 @@ depends: [
 synopsis: "An LR(1) parser generator"
 url {
   src:
-    "https://gitlab.inria.fr/fpottier/menhir/repository/20190626/archive.tar.gz"
+    "https://gitlab.inria.fr/fpottier/menhir/repository/20190924/archive.tar.gz"
   checksum: [
-    "md5=783961f8d124449a1a335cc8e50f013f"
-    "sha512=bacc5161682130d894a6476fb79363aa73e5582543265a0c23c9a1f9d974007c04853dc8f6faa2b8bd2e82b2323b8604dcc4cb74308af667698079b394dfd492"
+    "md5=677f1997fb73177d5a00fa1b8d61c3ef"
+    "sha512=ea8a9a6d773529cf6ac05e4c6c4532770fbb8e574c9b646efcefe90d9f24544741e3e8cfd94c8afea0447e34059a8c79c2829b46764ce3a3d6dcb3e7f75980fc"
   ]
 }

--- a/esy.lock/opam/mmap.1.1.0/opam
+++ b/esy.lock/opam/mmap.1.1.0/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/mirage/mmap"
 bug-reports: "https://github.com/mirage/mmap/issues"
 doc: "https://mirage.github.io/mmap/"
 dev-repo: "git+https://github.com/mirage/mmap.git"
-license: "LGPL 2.1 with linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/esy.lock/opam/ocaml-migrate-parsetree.1.4.0/opam
+++ b/esy.lock/opam/ocaml-migrate-parsetree.1.4.0/opam
@@ -4,7 +4,7 @@ authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
   "Jérémie Dimino <jeremie@dimino.org>"
 ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
 bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"

--- a/esy.lock/opam/ocamlbuild.0.14.0/opam
+++ b/esy.lock/opam/ocamlbuild.0.14.0/opam
@@ -3,7 +3,7 @@ maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
 authors: ["Nicolas Pouillard" "Berke Durak"]
 homepage: "https://github.com/ocaml/ocamlbuild/"
 bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
 build: [

--- a/esy.lock/opam/ppx_derivers.1.2.1/opam
+++ b/esy.lock/opam/ppx_derivers.1.2.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "jeremie@dimino.org"
 authors: ["Jérémie Dimino"]
-license: "BSD3"
+license: "BSD-3-Clause"
 homepage: "https://github.com/ocaml-ppx/ppx_derivers"
 bug-reports: "https://github.com/ocaml-ppx/ppx_derivers/issues"
 dev-repo: "git://github.com/ocaml-ppx/ppx_derivers.git"

--- a/esy.lock/opam/re.1.9.0/opam
+++ b/esy.lock/opam/re.1.9.0/opam
@@ -8,7 +8,7 @@ authors: [
   "Rudi Grinberg"
   "Gabriel Radanne"
 ]
-license: "LGPL-2.0 with OCaml linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/ocaml-re"
 bug-reports: "https://github.com/ocaml/ocaml-re/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml-re.git"

--- a/esy.lock/opam/result.1.4/opam
+++ b/esy.lock/opam/result.1.4/opam
@@ -4,7 +4,7 @@ authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/result"
 dev-repo: "git+https://github.com/janestreet/result.git"
 bug-reports: "https://github.com/janestreet/result/issues"
-license: "BSD3"
+license: "BSD-3-Clause"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"

--- a/esy.lock/opam/tyxml.4.3.0/opam
+++ b/esy.lock/opam/tyxml.4.3.0/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/ocsigen/tyxml/"
 bug-reports: "https://github.com/ocsigen/tyxml/issues"
 doc: "https://ocsigen.org/tyxml/manual/"
 dev-repo: "git+https://github.com/ocsigen/tyxml.git"
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 
 build: [
   ["dune" "subst"] {pinned}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@opam/dune": "*",
     "@opam/lwt": "^4.0.0",
-    "ocaml": "~4.7.0",
+    "ocaml": "^4.7.0",
     "@opam/merlin": "^3.2.2",
     "@opam/yojson": "^1.7.0",
     "@esy-ocaml/reason": "*",
@@ -25,6 +25,6 @@
   },
   "devDependencies": {
     "@opam/merlin": "^3.2.2",
-    "ocaml": "~4.7.0"
+    "ocaml": "^4.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "devDependencies": {
     "@opam/merlin": "^3.2.2",
-    "ocaml": "^4.7.0"
+    "ocaml": "4.8.1000"
   }
 }

--- a/src/Rpc.re
+++ b/src/Rpc.re
@@ -164,7 +164,7 @@ let start =
             let buffer = Bytes.create(len);
             let read = ref(0);
             while (read^ < len) {
-              let n = Pervasives.input(input, buffer, read^, len - read^);
+              let n = Stdlib.input(input, buffer, read^, len - read^);
               read := read^ + n;
             };
 


### PR DESCRIPTION
Required for https://github.com/onivim/oni2/pull/801

It might be a good idea to build with the release profile, and perhaps add a `buildDev` that does not for development, to keep warnings as errors from breaking stuff downstream when new warnings are added in minor compiler versions, such as the deprecation of `Pervasives` in this case.