### PR TITLE
Refactoring: Remove pump, replace with scheduler

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,9 +37,9 @@ jobs:
 
   steps:
   - template: .ci/use-node.yml
-  - template: .ci/restore-build-cache.yml
+  # - template: .ci/restore-build-cache.yml
   - template: .ci/esy-build-steps.yml
-  - template: .ci/publish-build-cache.yml
+  # - template: .ci/publish-build-cache.yml
 
 - job: Windows
   timeoutInMinutes: 0

--- a/src/Rpc.re
+++ b/src/Rpc.re
@@ -18,7 +18,6 @@ type t = {
   writeMutex: Mutex.t,
   messageHandler: (message, t) => unit,
   mutable shouldClose: bool,
-  mutable pendingMessages: list(message),
 }
 and responseHandler = (Response.t, t) => unit;
 
@@ -133,7 +132,6 @@ let start =
     messageHandler,
     nextRequestId: 0,
     shouldClose: false,
-    pendingMessages: [],
     pendingRequests: IntMap.empty,
   };
 

--- a/src/Rpc.rei
+++ b/src/Rpc.rei
@@ -4,6 +4,7 @@ type notificationHandler = (Notification.t, t) => unit;
 type requestHandler = (Request.t, t) => result(Yojson.Safe.t, string);
 type closeHandler = unit => unit;
 type errorMessageHandler = string => unit;
+type scheduler = (unit => unit) => unit;
 
 let start:
   (
@@ -11,6 +12,7 @@ let start:
     ~onRequest: requestHandler,
     ~onClose: closeHandler,
     ~onError: errorMessageHandler=?,
+    ~scheduler: scheduler=?,
     in_channel,
     out_channel
   ) =>
@@ -21,10 +23,5 @@ let sendNotification: (t, string, Yojson.Safe.t) => unit;
 type responseHandler = (Response.t, t) => unit;
 
 let sendRequest: (t, string, Yojson.Safe.t, responseHandler) => unit;
-
-/*
- * Calling 'pump' is required to handle pending notifications and requests
- */
-let pump: t => unit;
 
 let stop: t => unit;


### PR DESCRIPTION
The `pump` method was a way to force the consumer to execute the actual message handlers on a _main_ thread. 

However, this is a heavy-weight API, and requires the consumer to periodically call 'pump' - a simpler API is to offer a 'scheduler' function. When a message or response is received, we'll let the consumer handle it when they want. The default `scheduler` just runs from the context of the read thread, which might work for simple applications, but others will require control of when this processing happens (like Onivim 2).