### PR TITLE
require dune 2.x and fix install failure

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "19795d58810314add7a4c809269fec50",
+  "checksum": "31d2db6dab8f8f03d82eb6d8222595df",
   "root": "reason-jsonrpc@link-dev:./package.json",
   "node": {
     "refmterr@3.3.0@d41d8cd9": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "esy": {
     "build": "dune build --root . -j4",
     "install": [
-        "esy-installer reason-jsonrpc.install",
-        "esy-installer reason-jsonrpc-test.install"
+        "esy-installer #{self.target_dir}/default/reason-jsonrpc.install",
+        "esy-installer #{self.target_dir}/default/reason-jsonrpc-test.install"
     ]
   },
   "dependencies": {
-    "@opam/dune": "*",
+    "@opam/dune": "^2.0.0",
     "@opam/lwt": "^4.0.0",
     "ocaml": "^4.7.0",
     "@opam/merlin": "^3.2.2",


### PR DESCRIPTION
With dune 2.x, install files are no longer automatically promoted to the source directory. Which is a good thing, especially when it's cached, because it affects the reproducibility of builds. This therefore references the install files in `_build/install` instead, and also requires `dune 2.x` in case this doesn't work on earlier versions.